### PR TITLE
Remove hashtag column. Fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,39 +5,39 @@ This repo tracks upcoming hackathons. To add a hackathon to this list, please su
 
 Inspired by the [Developer Conferences](https://github.com/MurtzaM/Developer-Conferences) repo.
 
-| Hackathon                                                | Location        | Date (2014)            | Hashtag    |
-| -------------------------------------------------------------- |-------------  | :---------------------:| :----------:| 
-| [~~Smart Money Hackathon~~](http://www.eventbrite.com/e/smart-money-hackathon-registration-11443791689) | ~~San Francisco, CA~~ | ~~6.6 - 6.8~~ | |
-| [~~AngelHack Boston~~](http://www.angelhack.com/event/angelhack-boston-spring-2014/) | ~~Boston, MA~~ | ~~6.7 - 6.8~~ | |
-| [~~Hamburg Geekettes & OTS HH Hackathon~~](http://hamburg-hackathon.de/hackathon/) | ~~Hamburg, Germany~~ | ~~6.7 - 6.8~~ | |
-| [~~IDOL OnDemand Hackathon~~](http://www.eventbrite.com/e/idol-ondemand-hackathon-unleashing-innovation-and-breaking-boundaries-tickets-10845853239) | ~~San Francisco, CA~~ | ~~6.7 - 6.8~~ | |
-| [~~AngelHack Sao Paulo~~](http://www.angelhack.com/event/angelhack-sao-paulo-spring-2014/) | ~~Sao Paulo, Brazil~~ | ~~6.7 - 6.8~~ | |
-| [~~AngelHack Delhi~~](http://www.angelhack.com/event/angelhackdelhispring-2014/) | ~~Gurgaon, India~~ | ~~6.7 - 6.8~~ | |
-| [AngelHack London](http://www.angelhack.com/event/angelhack-london-spring-2014/) | London, United Kingdom | 6.14 - 6.15 | |
-| [AngelHack Mexico City](http://www.angelhack.com/event/angelhack-mexico-city-spring-2014/) | Cuauhtemoc, Mexico D.F. | 6.14 - 6.15 | |
-| [Pre-I/O Glass Hackathon](https://www.eventbrite.com/e/pre-io-google-glass-hackathon-tickets-11494645795) | San Francisco, CA | 6.20 - 6.21 | |
-| [AngelHack Tel Aviv](http://www.angelhack.com/event/angelhack-tel-aviv-spring-2014/) | Tel Aviv, Israel | 6.20 - 6.21 | |
-| [AngelHack Kuala Lumpur](http://www.angelhack.com/event/angelhack-kuala-lumpur-spring-2014/) | Kuala Lumpur, Malaysia | 6.21 - 6.22 | |
-| [AngelHack Phoenix](http://www.angelhack.com/event/angelhack-phoenix-arizona-spring-2014/) | Tempe, AZ | 6.21 - 6.22 | |
-| [AngelHack Toronto](http://www.angelhack.com/event/angelhack-toronto-spring-2014/) | Toronto, Canada | 6.21 - 6.22 | |
-| [SmallBizDev Hackathon](http://smallbizdevhackathon.com/event/san-francisco/) | San Francisco, CA | 6.21 - 6.22 | |
-| [Startup Weekend Denver](http://denver.startupweekend.org) | Denver, CO | 6.27 - 6.29 | |
-| [AngelHack Athens](http://www.angelhack.com/event/angelhackathensspring-2014/) | Athens, Greece | 6.28 - 6.29 | |
-| [AngelHack Buenos Aires](http://www.angelhack.com/event/angelhack-buenos-aires-spring-2014/) | Buenos Aires, Argentina | 6.28 - 6.29 | |
-| [Seattle Wearables Hackathon](http://www.meetup.com/Seattle-Hackathons/events/184601052/) | Seattle, WA | 7.12 - 7.13 | |
-| [AngelHack Manila](http://www.angelhack.com/event/angelhackmanilaspring-2014/) | TBD | 7.18 - 7.20 | |
-| [AngelHack Sillicon Valley](http://www.angelhack.com/event/angelhack-silicon-valley-spring-2014/) | Redwood City, CA | 7.19 - 7.20 | |
-| [SmallBizDev Hackathon](http://smallbizdevhackathon.com/event/chicago/) | Chicago, IL | 7.19 - 7.20 | |
-| [AT&T Mobile App Hackathon - Connected Car](http://www.eventbrite.com/e/att-mobile-app-hackathon-connected-car-seattle-tickets-11385922601) | Seattle, WA | 7.25 - 7.26 | |
-| [Startup Weekend Mobile/Wearables Seattle](http://www.up.co/communities/usa/seattle/startup-weekend/3912) | Seattle, WA | 7.25 - 7.27 | |
-| [Startup Weekend Seattle](http://www.up.co/communities/usa/seattle/startup-weekend/4001) | Seattle, WA | 8.22 - 8.24 | |
-| [PennApps X](http://2014f.pennapps.com/) | Philadelphia, PA | 9.12 - 9.14 | #pennappsX |
-| [SmallBizDev Hackathon](http://smallbizdevhackathon.com/event/new-york/) | New York, NY | 9.13 - 9.14 | |
-| [Startup Weekend Women Seattle](http://www.up.co/communities/usa/seattle/startup-weekend/3658) | Seattle, WA | 9.26 - 9.28 | |
-| [AT&T Mobile App Hackathon Seattle - Women in Tech](https://www.eventbrite.com/e/att-mobile-app-hackathon-seattle-women-in-tech-tickets-10931489379) | Seattle, WA | 10.3 - 10.4 | |
-| [Dubhacks](http://dubhacks.co/) | Seattle, WA | 10.17 - 10.18 | |
-| [Facebook Summer of Hack](http://facebook.com/hackathon) | Seattle, WA | TBA | |
-| [Facebook Summer of Hack](http://facebook.com/hackathon) | New York, NY | TBA | |
+| Hackathon                                                | Location        | Date (2014)            |
+| -------------------------------------------------------------- |-------------  | :---------------------:|
+| [~~Smart Money Hackathon~~](http://www.eventbrite.com/e/smart-money-hackathon-registration-11443791689) | ~~San Francisco, CA~~ | ~~6.6 - 6.8~~ |
+| [~~AngelHack Boston~~](http://www.angelhack.com/event/angelhack-boston-spring-2014/) | ~~Boston, MA~~ | ~~6.7 - 6.8~~ |
+| [~~Hamburg Geekettes & OTS HH Hackathon~~](http://hamburg-hackathon.de/hackathon/) | ~~Hamburg, Germany~~ | ~~6.7 - 6.8~~ |
+| [~~IDOL OnDemand Hackathon~~](http://www.eventbrite.com/e/idol-ondemand-hackathon-unleashing-innovation-and-breaking-boundaries-tickets-10845853239) | ~~San Francisco, CA~~ | ~~6.7 - 6.8~~ |
+| [~~AngelHack Sao Paulo~~](http://www.angelhack.com/event/angelhack-sao-paulo-spring-2014/) | ~~Sao Paulo, Brazil~~ | ~~6.7 - 6.8~~ |
+| [~~AngelHack Delhi~~](http://www.angelhack.com/event/angelhackdelhispring-2014/) | ~~Gurgaon, India~~ | ~~6.7 - 6.8~~ |
+| [AngelHack London](http://www.angelhack.com/event/angelhack-london-spring-2014/) | London, United Kingdom | 6.14 - 6.15 |
+| [AngelHack Mexico City](http://www.angelhack.com/event/angelhack-mexico-city-spring-2014/) | Cuauhtemoc, Mexico D.F. | 6.14 - 6.15 |
+| [Pre-I/O Glass Hackathon](https://www.eventbrite.com/e/pre-io-google-glass-hackathon-tickets-11494645795) | San Francisco, CA | 6.20 - 6.21 |
+| [AngelHack Tel Aviv](http://www.angelhack.com/event/angelhack-tel-aviv-spring-2014/) | Tel Aviv, Israel | 6.20 - 6.21 |
+| [AngelHack Kuala Lumpur](http://www.angelhack.com/event/angelhack-kuala-lumpur-spring-2014/) | Kuala Lumpur, Malaysia | 6.21 - 6.22 |
+| [AngelHack Phoenix](http://www.angelhack.com/event/angelhack-phoenix-arizona-spring-2014/) | Tempe, AZ | 6.21 - 6.22 |
+| [AngelHack Toronto](http://www.angelhack.com/event/angelhack-toronto-spring-2014/) | Toronto, Canada | 6.21 - 6.22 |
+| [SmallBizDev Hackathon](http://smallbizdevhackathon.com/event/san-francisco/) | San Francisco, CA | 6.21 - 6.22 |
+| [Startup Weekend Denver](http://denver.startupweekend.org) | Denver, CO | 6.27 - 6.29 |
+| [AngelHack Athens](http://www.angelhack.com/event/angelhackathensspring-2014/) | Athens, Greece | 6.28 - 6.29 |
+| [AngelHack Buenos Aires](http://www.angelhack.com/event/angelhack-buenos-aires-spring-2014/) | Buenos Aires, Argentina | 6.28 - 6.29 |
+| [Seattle Wearables Hackathon](http://www.meetup.com/Seattle-Hackathons/events/184601052/) | Seattle, WA | 7.12 - 7.13 |
+| [AngelHack Manila](http://www.angelhack.com/event/angelhackmanilaspring-2014/) | TBD | 7.18 - 7.20 |
+| [AngelHack Sillicon Valley](http://www.angelhack.com/event/angelhack-silicon-valley-spring-2014/) | Redwood City, CA | 7.19 - 7.20 |
+| [SmallBizDev Hackathon](http://smallbizdevhackathon.com/event/chicago/) | Chicago, IL | 7.19 - 7.20 |
+| [AT&T Mobile App Hackathon - Connected Car](http://www.eventbrite.com/e/att-mobile-app-hackathon-connected-car-seattle-tickets-11385922601) | Seattle, WA | 7.25 - 7.26 |
+| [Startup Weekend Mobile/Wearables Seattle](http://www.up.co/communities/usa/seattle/startup-weekend/3912) | Seattle, WA | 7.25 - 7.27 |
+| [Startup Weekend Seattle](http://www.up.co/communities/usa/seattle/startup-weekend/4001) | Seattle, WA | 8.22 - 8.24 |
+| [PennApps X](http://2014f.pennapps.com/) | Philadelphia, PA | 9.12 - 9.14 |
+| [SmallBizDev Hackathon](http://smallbizdevhackathon.com/event/new-york/) | New York, NY | 9.13 - 9.14 |
+| [Startup Weekend Women Seattle](http://www.up.co/communities/usa/seattle/startup-weekend/3658) | Seattle, WA | 9.26 - 9.28 |
+| [AT&T Mobile App Hackathon Seattle - Women in Tech](https://www.eventbrite.com/e/att-mobile-app-hackathon-seattle-women-in-tech-tickets-10931489379) | Seattle, WA | 10.3 - 10.4 |
+| [Dubhacks](http://dubhacks.co/) | Seattle, WA | 10.17 - 10.18 |
+| [Facebook Summer of Hack](http://facebook.com/hackathon) | Seattle, WA | TBA |
+| [Facebook Summer of Hack](http://facebook.com/hackathon) | New York, NY | TBA |
 
 | Hackathon                                                | Location        | Date (2015)            | Hashtag    |
 | :--------------------------------------------------------------: |:-------------:  | :---------------------:| :----------:| 


### PR DESCRIPTION
I don't people who are going to look at this are going to care about the hashtags of hackathons. They'll just go to the hackathon, which will advertise the twitter hashtag themselves. Also:
- **Very few hackathons post** their hashtags online (if they have one)
- **Hashtags aren't as popular** with hackathons as opposed to devconfs.
