### PR TITLE
Add a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: upcoming past
+
+upcoming:
+	echo 'name,url,location,dates' > upcoming.csv
+	cat README.md | sed 's/^| \[\(.*\)\](\(.*\)) | \(.*\) | \(.*\) |$$/"\1","\2","\3","\4"/;tx;d;:x' >> upcoming.csv
+
+past:
+	echo 'name,url,location,dates' > past.csv
+	cat Past-Hackathons.md | sed 's/^| \[\(.*\)\](\(.*\)) | \(.*\) | \(.*\) |$$/"\1","\2","\3","\4"/;tx;d;:x' >> past.csv
+
+clean:
+	rm upcoming.csv past.csv


### PR DESCRIPTION
Running the makefile will generate a csv list of the upcoming and past
hackathons.  Running make upcoming or make past will only generate the
respective csv files.  Running make clean removes any csv files
generated by make.  This has been tested on GNU sed and GNU make.  It
may behave differently on non GNU systems such as OSX.