### PR TITLE
CodeDay added

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Inspired by the [Developer Conferences](https://github.com/MurtzaM/Developer-Con
 | [HackDuke](http://www.hackduke.org) | Durham, NC | 11.7 - 11.8 |
 | [MasterCard Masters of Code: New York](http://www.eventbrite.com/e/mastercard-masters-of-code-new-york-tickets-14977044744?aff=es2) | New York City, NY | 11.7 - 11.8 |
 | [Technica](http://gotechnica.org/) | College Park, MD | 11.7 - 11.8 |
+| [CodeDay](https://codeday.org/) | 19 Cities, US | 11.7 - 11.8 |
 | [HackNJIT](http://hacknjit.org/) | Newark, NJ | 11.8 - 11.9 |
 | [HackHarvard](http://hackharvard.org/) | Cambridge, MA | 11.13 - 11.15 |
 | [HackSC](http://hacksc.com/) | Los Angeles, CA | 11.13 - 11.15 |


### PR DESCRIPTION
Added CodeDay(https://codeday.org/) to the list of hackathons.