### PR TITLE
Added Melbourne Space Hack to the list

### DIFF
--- a/Past-Hackathons.md
+++ b/Past-Hackathons.md
@@ -643,3 +643,4 @@ To add a hackathon to this list, please submit an issue or fork this repo and su
 | [THack Berlin Travel Hackathon](https://www.eventbrite.com/e/thack-berlin-travel-hackathon-tickets-20834398246) | Berlin, Germany | 3.4 |
 | [BrickHack](https://brickhack.io/) | Rochester, NY | 3.5 - 3.6 |
 | [HackUMBC](https://hackumbc.org/) | Baltimore County, MD | 3.5 - 3.6 |
+| [Melbourne Space Hack](http://www.finalfrontier.co/hackathon/)| Melbourne, Australia | 7.1 - 7.2 |

--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ Inspired by the [Developer Conferences](https://github.com/MurtzaM/Developer-Con
 | [MetroHacks](http://metrohacks.co) | Boston, MA | 5.21 - 5.22 |
 | [WellesleyHacks](http://wellesleyhacks.com/) | Wellelsey, MA | 5.28 |
 | [Cyclehack Berlin](http://cyclehackberlin.de) | Berlin, Germany | 6.24 - 6.26 |
+| [Melbourne Space Hack](http://www.finalfrontier.co/hackathon/)| Melbourne, Australia | 7.1 - 7.2 |
 


### PR DESCRIPTION
Melbourne Space Hack

Get ready for a hackathon that’s out of this world.

Melbourne Space Hack
Ticket: $10
Friday, 1 July (6pm) – Saturday, 2 July (6pm)
Winners announced Saturday, 6:30 – 8pm
http://www.finalfrontier.co/hackathon/

The #MelbSpaceHack, part of the Final Frontier Festival being run by the Melbourne Space Program, is a 24-hour competition where teams focus on developing solutions to space-centric problems. You'll choose one challenge from the areas of hardware, software or space law.

There are pre-hackathon workshops hosted by bDIGITAL to help you prepare, and there’ll be post-hackathon support to help the best solutions develop their concept and gain real traction.

The workshops will run from 12PM - 3:30PM on Friday, 1 July, with the hackathon challenges being announced at 6PM that night to kick off the hackathon competition.

All of this – plus catered lunch and dinner on Saturday – is included in your $10 ticket.
